### PR TITLE
Iterative deepening, history heuristic, Reduced hash table entry size

### DIFF
--- a/Astarion.cpp
+++ b/Astarion.cpp
@@ -109,6 +109,7 @@ int main()
 
     generateTables();
     clearHashmap();
+    clearHistory();
     initHashmap(256);
     while (std::getline(std::cin, input)) { //uci loop
         std::stringstream inputSS(input);
@@ -119,9 +120,10 @@ int main()
         }
         if (tokens[0] == "go") {
             nodes = 0;
-            negamaxHelper(color, whiteBoards, blackBoards, miscBoards, 7, board2);
+            negamaxHelper(color, whiteBoards, blackBoards, miscBoards, 8, board2);
             clearHashmap();
             clearKillers();
+            clearHistory();
             nodes = 0;
             repetition.clear();
         }

--- a/Board.cpp
+++ b/Board.cpp
@@ -619,6 +619,13 @@ void clearKillers() {
     }
 }
 
+void clearHistory() {
+    for (int i = 0; i < 12; i++) {
+        for (int j = 0; j < 64; j++) {
+            history[i][j] = 0;
+        }
+    }
+}
 
 
 

--- a/Board.h
+++ b/Board.h
@@ -15,5 +15,6 @@ void addBitBoardPiece(int piece, int dest, uint64_t whiteBoards[7], uint64_t bla
 void removeBitBoardPiece(int piece, int dest, uint64_t whiteBoards[7], uint64_t blackBoards[7], uint64_t miscBoards[4]);
 void updateMiscBoards(uint64_t whiteBoards[7], uint64_t blackBoards[7], uint64_t miscBoards[4]);
 void clearKillers();
+void clearHistory();
 void makeMove(int move, int board[], uint64_t whiteBoards[], uint64_t blackBoards[], uint64_t miscBoards[], int& capturedPiece, int& source, int& dest, int& piece, int color, unsigned long& kingBit);
 void unMakeMove(int move, int board[], uint64_t whiteBoards[], uint64_t blackBoards[], uint64_t miscBoards[], int& capturedPiece, int& source, int& dest, int& piece, int color, uint64_t castleRights);

--- a/Globals.cpp
+++ b/Globals.cpp
@@ -43,6 +43,7 @@ const int k = 12;*/
 int nodes = 0;
 
 int killers[30][2];
+int history[12][64];
 
 
 std::unordered_map<int, char> valToPiece;

--- a/Globals.h
+++ b/Globals.h
@@ -29,6 +29,7 @@ extern uint64_t notHGFile;
 extern int nodes;
 
 extern int killers[30][2];
+extern int history[12][64];
 
 const int infinity = 200000;
 const int mateVal = 100000;

--- a/TranspositionTable.cpp
+++ b/TranspositionTable.cpp
@@ -1,9 +1,12 @@
 #include <cstdint>
+#include <iostream>
 #include "TranspositionTable.h"
 #include "Zobrist.h"
 
 int hashmapSize = 0;
 Entry* hashmap = nullptr;
+
+int currAge = 0;
 
 void clearHashmap() {
 	Entry* temp = nullptr;
@@ -13,6 +16,7 @@ void clearHashmap() {
 		temp->flag = 0;
 		temp->value = 0;
 		temp->bestMove = 0;
+		temp->age = 0;
 	}
 }
 
@@ -28,6 +32,7 @@ void initHashmap(int mb) {
 	}
 	else {
 		clearHashmap();
+		//std::cout << "Hashmap init with size: " << hashmapSize << std::endl;
 	}
 }
 
@@ -55,14 +60,18 @@ int probeHash(int depth, int alpha, int beta, int &bestMove) {
 
 void recordEntry(int depth, int val, int hashFlag, int bestMove) {
 	Entry* newEntry = &hashmap[zobristKey % hashmapSize];
-	if (newEntry->key == zobristKey && newEntry->depth >= depth) { //dont overwrite entry
+	/*
+	if (newEntry->depth >= depth) { //dont overwrite entry
 		return;
+	}*/
+	if (currAge > newEntry->age || newEntry->depth <= depth) {
+		newEntry->key = zobristKey;
+		newEntry->depth = depth;
+		newEntry->flag = hashFlag;
+		newEntry->value = val;
+		newEntry->bestMove = bestMove;
+		newEntry->age = currAge;
 	}
-	newEntry->key = zobristKey;
-	newEntry->depth = depth;
-	newEntry->flag = hashFlag;
-	newEntry->value = val;
-	newEntry->bestMove = bestMove;
 }
 
 Entry* getEntry() {

--- a/TranspositionTable.h
+++ b/TranspositionTable.h
@@ -8,12 +8,15 @@ const int hashFlagEmpty = -1;
 
 const int noEntry = 99999;
 
+extern int currAge;
+
 struct Entry {
 	uint64_t key;
-	int depth;
-	int flag;
+	uint8_t depth;
+	uint8_t flag;
 	int value;
 	int bestMove;
+	uint8_t age;
 };
 
 extern int hashmapSize;


### PR DESCRIPTION
- Iterative deepening
- History heuristic
- Reduced hash table entry size therefore increasing size of hash table. Drastically increased speed, prior to this change I would get a different amount of nodes every search of the same position. Only reason i could think of was different hashes, hashing to the same index. With the increased size the amount of nodes is consistent and overall speed way faster.